### PR TITLE
Fix windows build and audio

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,7 +1,8 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{HostId, PlayStreamError, Stream};
+use cpal::HostId;
 use eyre::*;
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 use rustfft::{num_complex::Complex32, Fft, FftPlanner};
 
@@ -12,62 +13,66 @@ pub struct AudioContext {
     pub sample_rate: u32,
     pub num_channels: u16,
     pub host_id: HostId,
-    stream: Stream,
     sample_buffer: Arc<Mutex<Vec<Complex32>>>,
     fft: Arc<dyn Fft<f32>>,
     inner: Vec<Complex32>,
     scratch_area: Vec<Complex32>,
 }
 
-impl AudioContext {
-    pub fn new() -> Result<Self> {
-        let host = cpal::default_host();
+fn start_audio_thread() -> Result<AudioContext> {
+    let host = cpal::default_host();
 
-        let device = host
-            .default_input_device()
-            .context("failed to find input device")?;
+    let device = host
+        .default_input_device()
+        .context("failed to find input device")?;
 
-        let config = device.default_input_config()?;
-        let sample_rate = config.sample_rate().0;
-        let num_channels = config.channels();
+    let config = device.default_input_config()?;
+    let sample_rate = config.sample_rate().0;
+    let num_channels = config.channels();
 
-        let err_fn = move |err| {
-            eprintln!("an error occured on stream: {}", err);
-        };
+    let err_fn = move |err| {
+        eprintln!("an error occured on stream: {}", err);
+    };
 
-        let inner = vec![Complex32::default(); FFT_SIZE];
-        let buff = Arc::new(Mutex::new(vec![Complex32::default(); FFT_SIZE]));
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(FFT_SIZE);
-        let scratch_area = vec![Complex32::default(); fft.get_inplace_scratch_len()];
+    let inner = vec![Complex32::default(); FFT_SIZE];
+    let buff = Arc::new(Mutex::new(vec![Complex32::default(); FFT_SIZE]));
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(FFT_SIZE);
+    let scratch_area = vec![Complex32::default(); fft.get_inplace_scratch_len()];
 
-        let stream = device.build_input_stream(
-            &config.into(),
-            {
-                let buff2 = Arc::clone(&buff);
-                move |data, _: &_| {
-                    let mut buff3 = buff2.lock().unwrap();
-                    write_input_data::<f32>(data, &mut buff3);
-                }
-            },
-            err_fn,
-        )?;
-
-        let config = AudioContext {
+    let stream = device.build_input_stream(
+        &config.into(),
+        {
+            let buff2 = Arc::clone(&buff);
+            move |data, _: &_| {
+                let mut buff3 = buff2.lock().unwrap();
+                write_input_data::<f32>(data, &mut buff3);
+            }
+        },
+        err_fn,
+    )?;
+    match stream.play() {
+        Err(e) => Err(Report::from(e)),
+        Ok(()) => Ok(AudioContext {
             sample_rate,
             num_channels,
             host_id: host.id(),
-            stream,
             sample_buffer: buff,
             fft,
             inner,
             scratch_area,
-        };
-        Ok(config)
+        }),
     }
+}
 
-    pub fn play(&mut self) -> Result<(), PlayStreamError> {
-        self.stream.play()
+impl AudioContext {
+    pub fn new() -> Result<Self> {
+        // Start the audio stream on another thread, to work around winit + cpal COM incompatibilities
+        // on Windows.
+        let context = thread::spawn(start_audio_thread)
+            .join()
+            .expect("Audio thread crashed")?;
+        Ok(context)
     }
 
     pub fn get_fft(&mut self, out: &mut [f32]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,6 @@ fn main() -> Result<()> {
 
     let mut audio_context = audio::AudioContext::new()?;
 
-    audio_context.play()?;
-
     let mut input = input::Input::new();
     let mut pause = false;
     let mut time = Instant::now();

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -7,6 +7,9 @@ use std::{
     sync::mpsc,
 };
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 use crate::create_folder;
 use crate::VIDEO_FOLDER;
 


### PR DESCRIPTION
The CommandExt trait is needed for recorder.rs to compile on Windows.

Also on Windows the cpal crate and winit crate disagree on what "apartment mode" the current thread's COM should operate in. Starting the cpal stream on another thread fixes this. Unfortunately cpal Stream objects aren't Send, so this requires removing stream from AudioContext.

I also fixed a small complaint from the validation layer that some queue family indices didn't match.